### PR TITLE
removed azdo url check

### DIFF
--- a/src/authentication/azdoServer.ts
+++ b/src/authentication/azdoServer.ts
@@ -1,23 +1,10 @@
 import * as vscode from 'vscode';
 
 export class AzdoManager {
-	// TODO WTF Does this do?
-	private _servers: Map<string, boolean> = new Map()
-		.set('dev.azure.com', true)
-		.set('ssh.dev.azure.com', true)
-		.set('vs-ssh.visualstudio.com', true);
-
 	public async isAzdo(host: vscode.Uri): Promise<boolean> {
 		if (host === null) {
 			return false;
 		}
-
-		for (const [key, value] of this._servers) {
-			if (key.includes(host.authority)) {
-				return value;
-			}
-		}
-
-		return host.authority.includes('.visualstudio.com');
+		return true;
 	}
 }


### PR DESCRIPTION
Explicit domain check is not required as the org url is entered explicitly by the user. This may resolve the issues with private AzDO deployment sucn as #55 