### PR TITLE
Add our extension name to the PAT request prompt

### DIFF
--- a/src/azdo/credentials.ts
+++ b/src/azdo/credentials.ts
@@ -76,7 +76,7 @@ export class CredentialStore implements vscode.Disposable {
 		Logger.debug(`Manual personal access token option chosen.`, CREDENTIALS_COMPONENT_ID);
 		const token = await vscode.window.showInputBox({
 			value: '',
-			prompt: 'Please provide PAT',
+			prompt: 'Azure Devops Pull Requests: Please provide PAT',
 			placeHolder: '',
 			password: true,
 		});


### PR DESCRIPTION
This is so the user has a clue what kind of PAT is required and which extension sent the request. There's also an [open issue](https://github.com/microsoft/vscode/issues/136856) for VS Code to automatically show this information (which would mean we could revert to the old prompt or use `Please provide PAT for Azure DevOps access`)