### PR TITLE
Implement Microsoft Auth provider

### DIFF
--- a/src/authentication/configuration.ts
+++ b/src/authentication/configuration.ts
@@ -5,19 +5,10 @@ export interface IHostConfiguration {
 	token: string | undefined;
 }
 
-export const AuthenticationScopes = [
-	'499b84ac-1321-427f-aa17-267ca6975798/.default',
-	'offline_access',
-	// Apparently app-specific scopes cannot be used with this authentication method
-	//'vso.code_write', // Code: Read & Write
-	//'vso.work_write', // Work items: Read & Write
-	//'vso.memberentitlementmanagement', // Member Entitlement Agreement: Read
-];
+export const AuthenticationScopes = ['499b84ac-1321-427f-aa17-267ca6975798/.default', 'offline_access'];
 
 export const AuthenticationOptions: vscode.AuthenticationGetSessionOptions = {
 	createIfNone: true,
-	// Used for development, asks to sign in on every load
-	//forceNewSession: true,
 };
 
 let USE_TEST_SERVER = false;

--- a/src/authentication/configuration.ts
+++ b/src/authentication/configuration.ts
@@ -5,6 +5,21 @@ export interface IHostConfiguration {
 	token: string | undefined;
 }
 
+export const AuthenticationScopes = [
+	'499b84ac-1321-427f-aa17-267ca6975798/.default',
+	'offline_access',
+	// Apparently app-specific scopes cannot be used with this authentication method
+	//'vso.code_write', // Code: Read & Write
+	//'vso.work_write', // Work items: Read & Write
+	//'vso.memberentitlementmanagement', // Member Entitlement Agreement: Read
+];
+
+export const AuthenticationOptions: vscode.AuthenticationGetSessionOptions = {
+	createIfNone: true,
+	// Used for development, asks to sign in on every load
+	//forceNewSession: true,
+};
+
 let USE_TEST_SERVER = false;
 
 export const HostHelper = class {

--- a/src/azdo/credentials.ts
+++ b/src/azdo/credentials.ts
@@ -2,6 +2,7 @@ import * as azdev from 'azure-devops-node-api';
 import { IRequestHandler } from 'azure-devops-node-api/interfaces/common/VsoBaseInterfaces';
 import { Identity } from 'azure-devops-node-api/interfaces/IdentitiesInterfaces';
 import * as vscode from 'vscode';
+import { AuthenticationOptions, AuthenticationScopes } from '../authentication/configuration';
 import Logger from '../common/logger';
 import { ITelemetry } from '../common/telemetry';
 import { SETTINGS_NAMESPACE } from '../constants';
@@ -73,13 +74,11 @@ export class CredentialStore implements vscode.Disposable {
 	private async requestPersonalAccessToken(): Promise<string | undefined> {
 		// Based on https://github.com/microsoft/azure-repos-vscode/blob/6bc90f0853086623486d0e527e9fe5a577370e9b/src/team-extension.ts#L74
 
-		Logger.debug(`Manual personal access token option chosen.`, CREDENTIALS_COMPONENT_ID);
-		const token = await vscode.window.showInputBox({
-			value: '',
-			prompt: 'Please provide PAT',
-			placeHolder: '',
-			password: true,
-		});
+		const session = await vscode.authentication.getSession('microsoft', AuthenticationScopes, AuthenticationOptions);
+		const token = session.accessToken;
+
+		vscode.window.showInformationMessage('Successfully authorized extension in DevOps');
+
 		if (token) {
 			this._telemetry.sendTelemetryEvent('auth.manual');
 		}


### PR DESCRIPTION
Replace requesting PATs from user with the built-in authentication provider.  Related to https://github.com/ankitbko/vscode-pull-request-azdo/issues/68

Apparently scopes cannot be used in the configuration array as I would've expected, I'm not entirely sure about what kind of accessToken the user gets via the API and does it have way more permissions than what it's needed for this extension 🤔 

Tested it with a personal project in DevOps and it seemed to work fine. Let me know if anything comes to your mind, I'm happy to help!