### PR TITLE
Bugfix for #63 invalid arguments retrieving info for some prs

### DIFF
--- a/.github/issue-branch.yml
+++ b/.github/issue-branch.yml
@@ -1,0 +1,9 @@
+branchName: full
+silent: false
+autoCloseIssue: true
+
+branches:
+  - label: enhancement
+    prefix: feature/
+  - label: bug
+    prefix: bugfix/

--- a/src/view/treeNodes/fileChangeNode.ts
+++ b/src/view/treeNodes/fileChangeNode.ts
@@ -166,7 +166,7 @@ export class FileChangeNode extends TreeNode implements vscode.TreeItem {
 
 	updateShowOptions() {
 		const reviewThreads = this.pullRequest.reviewThreadsCache;
-		const reviewThreadsForNode = reviewThreads.filter(thread => !thread.isDeleted && thread.path === this.fileName);
+		let reviewThreadsForNode = reviewThreads.filter(thread => !thread.isDeleted && thread.path === this.fileName);
 
 		DecorationProvider.updateFileComments(
 			this.resourceUri,
@@ -174,6 +174,8 @@ export class FileChangeNode extends TreeNode implements vscode.TreeItem {
 			this.fileName,
 			reviewThreadsForNode.length > 0,
 		);
+		/* Some comments are attached to the file and have not reference/selection in the content. Need to be removed here. */
+		reviewThreadsForNode = reviewThreadsForNode.filter((thread) => thread.line !== undefined);
 
 		if (reviewThreadsForNode.length) {
 			reviewThreadsForNode.sort((a, b) => a.line - b.line);


### PR DESCRIPTION
updateShowOptions() assumed that all comments have line information. This is not the case for file comments. 
So the line was undefined and caused the exception with invalid arguments. 